### PR TITLE
chore: consolidate Docker action updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/claude-contrib/claude-sandbox
           tags: |
@@ -48,7 +48,7 @@ jobs:
             org.opencontainers.image.title=claude-sandbox
             org.opencontainers.image.description=Isolated, Nix-enabled Claude Code execution environment
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

Consolidates four separate Dependabot version bumps into a single PR, applied to the `docker:` job in `release.yml` (where the Docker build was moved after `docker.yml` was deleted in #7).

- `docker/login-action` v3 → v4 (supersedes #3)
- `docker/setup-buildx-action` v3 → v4 (supersedes #5)
- `docker/metadata-action` v5 → v6 (supersedes #2)
- `docker/build-push-action` v6 → v7 (supersedes #4)

Closes #8. Supersedes PRs #2, #3, #4, #5.

No `with:` block changes required — these major version bumps have no breaking input/output API changes for our usage patterns.

## Test plan

- [x] Verify all four version strings in `release.yml` reflect the new major versions
- [x] Confirm the workflow file is valid YAML with no syntax errors
- [x] The `docker` job will be exercised end-to-end on the next release publish