### PR TITLE
fix(ci): supply explicit tag value to metadata-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v6
       - uses: googleapis/release-please-action@v4
@@ -41,9 +42,9 @@ jobs:
         with:
           images: ghcr.io/claude-contrib/claude-sandbox
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.tag_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.tag_name }}
+            type=semver,pattern={{major}},value=${{ needs.release.outputs.tag_name }}
           labels: |
             org.opencontainers.image.title=claude-sandbox
             org.opencontainers.image.description=Isolated, Nix-enabled Claude Code execution environment


### PR DESCRIPTION
## Summary

- `docker/metadata-action@v6` with `type=semver` patterns requires a `refs/tags/...` git ref to derive a version string, but the Release workflow triggers on `push` to `main` (a branch ref), so tags came out empty and `build-push-action` errored with `tag is needed when pushing to registry`
- Expose `tag_name` from the `release` job outputs
- Pass `value=${{ needs.release.outputs.tag_name }}` to each semver tag pattern so the metadata action uses the release-please tag directly instead of the git ref

## Test plan

- [x] Merge to `main` triggers a release-please release
- [x] `release` job outputs a non-empty `tag_name` (e.g. `v0.2.2`)
- [x] `docker` job: `Docker metadata` step shows non-empty `DOCKER_METADATA_OUTPUT_TAGS`
- [x] `build-push-action` pushes image to `ghcr.io/claude-contrib/claude-sandbox` with correct version tags