### PR TITLE
fix: disable Nix seccomp BPF filtering for arm64 QEMU compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 RUN apt-get update && apt-get install -y curl git gh ripgrep sudo xz-utils ca-certificates && rm -rf "/var/lib/apt/lists/*"
 
-RUN curl -fsSL https://install.determinate.systems/nix | sh -s -- install linux --no-confirm --init none --no-start-daemon --extra-conf "sandbox = false"
+RUN curl -fsSL https://install.determinate.systems/nix | sh -s -- install linux --no-confirm --init none --no-start-daemon --extra-conf "sandbox = false" --extra-conf "filter-syscalls = false"
 
 RUN useradd -m -u 1001 -s /bin/bash claude
 


### PR DESCRIPTION
## Summary

- Adds `filter-syscalls = false` to the Nix installer config in the Dockerfile
- Fixes `unable to load seccomp BPF program: Invalid argument` crash during `linux/arm64` Docker image build under QEMU emulation
- Docker's own seccomp profile already provides syscall filtering at the container level, so this is safe

## Test plan

- [x] Verify the release workflow succeeds for both `linux/amd64` and `linux/arm64` platforms

Fixes workflow run [#23105439463](https://github.com/claude-contrib/claude-sandbox/actions/runs/23105439463)