### PR TITLE
test: remove stale ANTHROPIC_API_KEY assertion from _show_help tests

### DIFF
--- a/tests/claude.bats
+++ b/tests/claude.bats
@@ -37,10 +37,6 @@ setup() {
   [[ "$output" == *"--help"* ]]
 }
 
-@test "_show_help contains ANTHROPIC_API_KEY" {
-  run _show_help
-  [[ "$output" == *"ANTHROPIC_API_KEY"* ]]
-}
 
 @test "_show_help contains repo URL" {
   run _show_help


### PR DESCRIPTION
## Summary
- Removes the `_show_help contains ANTHROPIC_API_KEY` test that became stale after commit `54dc609` added `CLAUDE_SANDBOX` env var support — `_show_help` no longer references `ANTHROPIC_API_KEY`
- All 35 remaining tests pass

## Test plan
- [x] `bats tests/` — 35/35 tests pass