### PR TITLE
feat: bind mount --add-dir directories as read-only volumes in sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ claude --sandbox-help
 DEBUG=1 claude --sandbox
 ```
 
+## Argument Handling
+
+Some Claude CLI arguments are intercepted by the sandbox wrapper and handled specially before being forwarded to the container:
+
+| Argument | Sandbox behaviour |
+|----------|-------------------|
+| `--add-dir DIR` | The directory is bind-mounted **read-only** into the container at the same absolute path, then forwarded to `claude` inside the sandbox |
+
+```bash
+# Mount an extra directory read-only inside the sandbox
+claude --sandbox --add-dir /path/to/docs
+```
+
 ## Devcontainer Network
 
 If your project uses a [devcontainer](https://containers.dev/) (VS Code, Codespaces, devcontainer CLI), the sandbox automatically detects the running devcontainer and joins its Docker network. This lets Claude reach services (databases, APIs, etc.) defined in the devcontainer without any extra configuration.
@@ -144,7 +157,6 @@ These additional variables are handled specially:
 | `CLAUDE_CONFIG_DIR` | Claude Code config directory — defaults to `~/.config/claude`, must be under `~/.config` |
 | `GIT_CONFIG_GLOBAL` | Git global config file — defaults to `~/.config/git/config`, must be under `~/.config` |
 | `CLAUDE_SANDBOX` | Always run in sandbox mode — equivalent to passing `--sandbox` on every invocation |
-| `SSH_AUTH_SOCK` | SSH agent socket — bind-mounted into the container |
 | `DEBUG` | Enable debug tracing (`set -x`) |
 
 ### Settings

--- a/claude
+++ b/claude
@@ -21,12 +21,14 @@ claude-sandbox ${version}
 Usage: claude [flags] [claude args...]
 
 Flags:
-  --sandbox    Run claude inside a Docker sandbox container
+  --sandbox       Run claude inside a Docker sandbox container
   --sandbox-help  Show this help message and exit
+
+Claude args (intercepted in sandbox mode):
+  --add-dir DIR  bind-mounted read-only into the container
 
 Environment variables:
   CLAUDE_SANDBOX      Always run in sandbox mode (same as passing --sandbox)
-  SSH_AUTH_SOCK       SSH agent socket (forwarded to sandbox)
   DEBUG               Enable debug tracing (set -x)
 
 https://github.com/claude-contrib/claude-sandbox
@@ -138,6 +140,22 @@ _run_in_docker() {
       run_args+=(-T)
     fi
   fi
+
+  # Mount each --add-dir directory as a read-only bind volume.
+  local add_dir_path
+  for ((i = 1; i <= $#; i++)); do
+    case "${!i}" in
+    --add-dir)
+      i=$((i + 1))
+      add_dir_path="$(cd "${!i}" && pwd)"
+      run_args+=(--volume "$add_dir_path:$add_dir_path:ro")
+      ;;
+    --add-dir=*)
+      add_dir_path="$(cd "${!i#--add-dir=}" && pwd)"
+      run_args+=(--volume "$add_dir_path:$add_dir_path:ro")
+      ;;
+    esac
+  done
 
   # Launch the sandboxed claude session.
   _gum log --level info "Starting Claude sandbox..."

--- a/tests/claude.bats
+++ b/tests/claude.bats
@@ -574,6 +574,58 @@ SCRIPT
   rm -rf "$tmpdir"
 }
 
+@test "_run_in_docker mounts --add-dir directory as read-only volume" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  HOME="$tmpdir"
+  cd "$tmpdir"
+
+  local extra_dir
+  extra_dir="$(mktemp -d)"
+
+  _claude_script_dir="$REPO_ROOT"
+  unset SSH_AUTH_SOCK GH_TOKEN GITHUB_TOKEN CLAUDE_CONFIG_DIR GIT_CONFIG_GLOBAL
+
+  docker() {
+    case "$1" in
+      image) return 0 ;;
+      compose) echo "ARGS: $*" ;;
+    esac
+  }
+  export -f docker
+
+  run _run_in_docker --add-dir "$extra_dir"
+  [[ "$output" == *"--volume ${extra_dir}:${extra_dir}:ro"* ]]
+
+  rm -rf "$tmpdir" "$extra_dir"
+}
+
+@test "_run_in_docker resolves relative --add-dir path to absolute for mount" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  HOME="$tmpdir"
+
+  local extra_dir
+  extra_dir="$(mktemp -d)"
+  cd "$extra_dir"
+
+  _claude_script_dir="$REPO_ROOT"
+  unset SSH_AUTH_SOCK GH_TOKEN GITHUB_TOKEN CLAUDE_CONFIG_DIR GIT_CONFIG_GLOBAL
+
+  docker() {
+    case "$1" in
+      image) return 0 ;;
+      compose) echo "ARGS: $*" ;;
+    esac
+  }
+  export -f docker
+
+  run _run_in_docker --add-dir .
+  [[ "$output" == *"--volume ${extra_dir}:${extra_dir}:ro"* ]]
+
+  rm -rf "$tmpdir" "$extra_dir"
+}
+
 @test "_run_in_docker exposes GH_TOKEN to docker compose environment" {
   local tmpdir
   tmpdir="$(mktemp -d)"


### PR DESCRIPTION
Closes #41

## Summary

- Intercepts `--add-dir PATH` and `--add-dir=PATH` arguments in `_run_in_docker`, resolves each to an absolute path, and appends `--volume ABS:ABS:ro` to the Docker run args before forwarding the original arguments unchanged to `claude-exec.sh`
- Adds a dedicated **Argument Handling** section to `README.md` documenting the interception behaviour
- Adds a `Claude args (intercepted in sandbox mode)` section to `--sandbox-help`
- Adds two bats test cases: absolute path mount and relative path resolution

## Test plan

- [x] `bats tests/claude.bats` — 53/53 passing
- [x] Manual smoke test: `./claude --sandbox --add-dir /tmp/mydir claude --print "list files in /tmp/mydir"` — `/tmp/mydir` accessible read-only inside container